### PR TITLE
Fix default logging config

### DIFF
--- a/config_example.yml
+++ b/config_example.yml
@@ -36,7 +36,7 @@ LOGGING:
       formatter: plaintext
       stream: ext://sys.stdout
   loggers:
-    root:
+    '':
       level: INFO
       handlers: [console]
     committee:


### PR DESCRIPTION
In our environment we noticed that DAC service stopped logging anything after a few initial logs. Using `print` for additional logs showed that it was working as expected, but something was blocking log output. 

Per [this](https://stackoverflow.com/questions/7507825/where-is-a-complete-example-of-logging-config-dictconfig) thread, default config was misconfigured to use `root` instead of `''` (empty string) logger. This PR fixes this. 